### PR TITLE
Fix printf PRIu8 format string compile error in deckcontrol.cpp

### DIFF
--- a/deckcontrol.cpp
+++ b/deckcontrol.cpp
@@ -269,8 +269,8 @@ int main(int argc, char *argv[])
         uint8_t hours, minutes, seconds, frames;
         deckControl->GetTimecode(&currentTimecode, &deckError);
         currentTimecode->GetComponents(&hours, &minutes, &seconds, &frames);
-        printf("TC=%02"PRIu8":%02"PRIu8":%02"PRIu8":%02"PRIu8"\n",
-               hours, minutes, seconds, frames);
+        printf("TC=%02" PRIu8 ":%02" PRIu8 ":%02" PRIu8 ":%02" PRIu8 "\n",
+            hours, minutes, seconds, frames);     
         SAFE_RELEASE(currentTimecode);
         break;
     case CRASH_RECORD_START:


### PR DESCRIPTION
invalid literal suffix with PRIu8

added spaces